### PR TITLE
 Feat: Add Support for Notifications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,18 @@ module github.com/xasterKies/pomanalyzer
 
 go 1.21.4
 
-require github.com/mum4k/termdash v0.13.0
+require (
+	github.com/mattn/go-sqlite3 v1.14.23
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mum4k/termdash v0.13.0
+	github.com/spf13/viper v1.19.0
+)
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
-	github.com/mattn/go-sqlite3 v1.14.23 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
@@ -19,7 +22,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.19.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/notif/notif.go
+++ b/notif/notif.go
@@ -1,0 +1,55 @@
+package notif
+
+import "runtime"
+
+// serverity constants
+const (
+	SeverityLow = iota
+	SeverityNormal
+	SeverityUrgent
+)
+
+type Severity int
+
+// Notification schema
+type Notify struct {
+	title    string
+	message  string
+	severity Severity
+}
+
+// Initialize a new notification
+func New(title, message string, severity Severity) *Notify {
+	return &Notify{
+		title:    title,
+		message:  message,
+		severity: severity,
+	}
+}
+
+// Determines and returns each notification severity string.
+func (s Severity) String() string {
+	sev := "low"
+
+	switch s {
+	case SeverityLow:
+		sev = "low"
+	case SeverityNormal:
+		sev = "normal"
+	case SeverityUrgent:
+		sev = "critical"
+	}
+
+	if runtime.GOOS == "windows" {
+		switch s {
+		case SeverityLow:
+			sev = "Info"
+		case SeverityNormal:
+			sev = "Warning"
+		case SeverityUrgent:
+			sev = "Error"
+		}
+	}
+
+	return sev
+}

--- a/notif/notif_darwin.go
+++ b/notif/notif_darwin.go
@@ -2,24 +2,38 @@ package notif
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 )
 
 var command = exec.Command
 
-// Send sends notification for MacOs, if an error
-// occurs it is returned and the notification is not sent.
+// Send sends a notification for macOS using terminal-notifier,
+// then plays a notification sound using afplay.
 func (n Notify) Send() error {
+	// Send the notification using terminal-notifier.
 	notifCmdName := "terminal-notifier"
-
 	notifCmd, err := exec.LookPath(notifCmdName)
-
 	if err != nil {
 		return err
 	}
 
 	title := fmt.Sprintf("(%s) %s", n.severity, n.title)
-	notifCommand := command(notifCmd, "-title", title, "-message", n.message)
+	notifCommand := exec.Command(notifCmd, "-title", title, "-message", n.message)
+	if err := notifCommand.Run(); err != nil {
+		return err
+	}
 
-	return notifCommand.Run()
+	soundCmdName, err := exec.LookPath("afplay")
+	if err != nil {
+		return err
+	}
+
+	soundFile := "/System/Library/Sounds/Glass.aiff"
+	soundCommand := command(soundCmdName, soundFile)
+	if err := soundCommand.Run(); err != nil {
+		log.Printf("Failed to play sound: %v", err)
+	}
+
+	return nil
 }

--- a/notif/notif_darwin.go
+++ b/notif/notif_darwin.go
@@ -1,0 +1,25 @@
+package notif
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+var command = exec.Command
+
+// Send sends notification for MacOs, if an error
+// occurs it is returned and the notification is not sent.
+func (n Notify) Send() error {
+	notifCmdName := "terminal-notifier"
+
+	notifCmd, err := exec.LookPath(notifCmdName)
+
+	if err != nil {
+		return err
+	}
+
+	title := fmt.Sprintf("(%s) %s", n.severity, n.title)
+	notifCommand := command(notifCmd, "-title", title, "-message", n.message)
+
+	return notifCommand.Run()
+}

--- a/notif/notif_test.go
+++ b/notif/notif_test.go
@@ -1,0 +1,120 @@
+package notif
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Test for newly created notifications
+func TestNew(t *testing.T) {
+	testCases := []struct {
+		s Severity
+	}{
+		{SeverityLow},
+		{SeverityNormal},
+		{SeverityUrgent},
+	}
+
+	for _, tc := range testCases {
+		name := tc.s.String()
+		expMessage := "Message"
+		expTitle := "Title"
+		t.Run(name, func(t *testing.T) {
+			n := New(expTitle, expMessage, tc.s)
+			if n.message != expMessage {
+				t.Errorf("Expected %q, got %q instead\n", expMessage, n.message)
+			}
+			if n.title != expTitle {
+				t.Errorf("Expected %q, got %q instead\n", expTitle, n.title)
+			}
+			if n.severity != tc.s {
+				t.Errorf("Expected %q, got %q instead\n", tc.s, n.severity)
+			}
+		})
+	}
+}
+
+// Tests for Severity.String() - Testcases happen for each severity on each operating system
+// Since it is not possible to test on all OSs at the same time tests are written but in the program runtime
+// it checks to findout the OS it is running on and tests for that only. It skips the rest with t.Skip
+func TestSeverityString(t *testing.T) {
+	testCases := []struct {
+		s   Severity
+		exp string
+		os  string
+	}{
+		{SeverityLow, "low", "linux"},
+		{SeverityNormal, "normal", "linux"},
+		{SeverityUrgent, "critical", "linux"},
+		{SeverityLow, "Low", "darwin"},
+		{SeverityNormal, "Normal", "darwin"},
+		{SeverityUrgent, "Critical", "darwin"},
+		{SeverityLow, "Info", "windows"},
+		{SeverityNormal, "Warning", "windows"},
+		{SeverityUrgent, "Error", "windows"},
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf("%s%d", tc.os, tc.s)
+		t.Run(name, func(t *testing.T) {
+			if runtime.GOOS != tc.os {
+				t.Skip("Skipped: not OS", runtime.GOOS)
+			}
+			sev := tc.s.String()
+			if sev != tc.exp {
+				t.Errorf("Expected %q, got %q instead\n", tc.exp, sev)
+			}
+		})
+	}
+}
+
+// Test the external command functionality
+func mockCmd(exe string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess"}
+	cs = append(cs, exe)
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+// Test for the helper process
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	cmdName := ""
+
+	switch runtime.GOOS {
+	case "linux":
+		cmdName = "notify-send"
+	case "darwin":
+		cmdName = "terminal-notifier"
+	case "windows":
+		cmdName = "powershell"
+	}
+
+	if strings.Contains(os.Args[2], cmdName) {
+		os.Exit(0)
+	}
+
+	os.Exit(1)
+}
+
+// Test notification send
+func TestSend(t *testing.T) {
+	n := New("test title", "test msg", SeverityNormal)
+
+	command = mockCmd
+
+	err := n.Send()
+
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/notif/notif_windows.go
+++ b/notif/notif_windows.go
@@ -7,37 +7,44 @@ import (
 
 var command = exec.Command
 
-// Send notification for Windows
+// Send sends a Windows notification and plays a sound.
 func (n *Notify) Send() error {
 	notifCmdName := "powershell.exe"
 
+	// Look up the path for powershell.exe
 	notifCmd, err := exec.LookPath(notifCmdName)
 	if err != nil {
 		return err
 	}
 
-	// Powershell notification script - It is loosely based on the BaloonTip script
-	// developed by Boe Prox
-	psscript := fmt.Sprintf(`Add-Type -AssemblyName System.Windows.Forms
-	$notify = New-Object System.Windows.Forms.NotifyIcon
-	$notify.Icon = [System.Drawing.SystemIcons]::Information
-	$notify.BalloonTipIcon = %q
-	$notify.BalloonTipTitle = %q
-	$notify.BalloonTipText = %q
-	$notify.Visible = $True
-	$notify.ShowBalloonTip(10000)`,
-		n.severity, n.title, n.message,
-	)
+	// Build the PowerShell script for the balloon notification.
+	// Using single quotes to enclose strings inside the script.
+	psScript := fmt.Sprintf(`Add-Type -AssemblyName System.Windows.Forms;
+$notify = New-Object System.Windows.Forms.NotifyIcon;
+$notify.Icon = [System.Drawing.SystemIcons]::Information;
+$notify.BalloonTipIcon = '%s';
+$notify.BalloonTipTitle = '%s';
+$notify.BalloonTipText = '%s';
+$notify.Visible = $True;
+$notify.ShowBalloonTip(10000);`, n.severity, n.title, n.message)
 
-	// Slice of strings with required powershell arguements to run silently
-	args := []string{
+	// Create the command to send the notification.
+	notifArgs := []string{
 		"-NoProfile",
 		"-NonInteractive",
+		"-Command", psScript,
+	}
+	notifCommand := command(notifCmd, notifArgs...)
+	if err := notifCommand.Run(); err != nil {
+		return err
 	}
 
-	//Append the script to the arguements slice to pass it to the function that creates the command
-	args = append(args, psscript)
-
-	notifCommand := command(notifCmd, args...)
-	return notifCommand.Run()
+	soundScript := `(New-Object Media.SoundPlayer 'C:\Windows\Media\notify.wav').PlaySync();`
+	soundArgs := []string{
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command", soundScript,
+	}
+	soundCommand := command(notifCmd, soundArgs...)
+	return soundCommand.Run()
 }

--- a/notif/notif_windows.go
+++ b/notif/notif_windows.go
@@ -1,0 +1,43 @@
+package notif
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+var command = exec.Command
+
+// Send notification for Windows
+func (n *Notify) Send() error {
+	notifCmdName := "powershell.exe"
+
+	notifCmd, err := exec.LookPath(notifCmdName)
+	if err != nil {
+		return err
+	}
+
+	// Powershell notification script - It is loosely based on the BaloonTip script
+	// developed by Boe Prox
+	psscript := fmt.Sprintf(`Add-Type -AssemblyName System.Windows.Forms
+	$notify = New-Object System.Windows.Forms.NotifyIcon
+	$notify.Icon = [System.Drawing.SystemIcons]::Information
+	$notify.BalloonTipIcon = %q
+	$notify.BalloonTipTitle = %q
+	$notify.BalloonTipText = %q
+	$notify.Visible = $True
+	$notify.ShowBalloonTip(10000)`,
+		n.severity, n.title, n.message,
+	)
+
+	// Slice of strings with required powershell arguements to run silently
+	args := []string{
+		"-NoProfile",
+		"-NonInteractive",
+	}
+
+	//Append the script to the arguements slice to pass it to the function that creates the command
+	args = append(args, psscript)
+
+	notifCommand := command(notifCmd, args...)
+	return notifCommand.Run()
+}

--- a/notif/notify_linux.go
+++ b/notif/notify_linux.go
@@ -1,0 +1,20 @@
+package notif
+
+import "os/exec"
+
+var command = exec.Command
+
+// Send notification for linux system
+func (n *Notify) Send() error {
+	notifCmdName := "notify-send"
+
+	notifCmd, err := exec.LookPath(notifCmdName)
+
+	if err != nil {
+		return err
+	}
+
+	notifCommand := command(notifCmd, "-u", n.severity.String(), n.title, n.message)
+
+	return notifCommand.Run()
+}

--- a/notif/notify_linux.go
+++ b/notif/notify_linux.go
@@ -1,12 +1,15 @@
 package notif
 
-import "os/exec"
+import (
+	"os/exec"
+)
 
 var command = exec.Command
 
 // Send notification for linux system
 func (n *Notify) Send() error {
 	notifCmdName := "notify-send"
+	soundFile := "/usr/share/sounds/Yaru/stereo/message-new-instant.oga"
 
 	notifCmd, err := exec.LookPath(notifCmdName)
 
@@ -16,5 +19,19 @@ func (n *Notify) Send() error {
 
 	notifCommand := command(notifCmd, "-u", n.severity.String(), n.title, n.message)
 
-	return notifCommand.Run()
+	if err := notifCommand.Run(); err != nil {
+		return err
+	}
+
+	// Check if `paplay` is available; otherwise, use `ogg123`
+	soundCmdName, err := exec.LookPath("paplay")
+	if err != nil {
+		soundCmdName, err = exec.LookPath("ogg123")
+		if err != nil {
+			return nil
+		}
+	}
+
+	soundCommand := exec.Command(soundCmdName, soundFile)
+	return soundCommand.Run()
 }

--- a/pomodoro/interval.go
+++ b/pomodoro/interval.go
@@ -173,7 +173,7 @@ func tick(ctx context.Context, id int64, config *IntervalConfig,
 
 		var message string
 
-		if i.State != StatePaused {
+		if i.State == StateDone {
 			if i.Category == CategoryPomodoro {
 				message = "Time to take a break. Start break timer."
 			} else {

--- a/pomodoro/interval.go
+++ b/pomodoro/interval.go
@@ -63,22 +63,22 @@ func NewConfig(repo Repository, pomodoro, shortBreak,
 
 	c := &IntervalConfig{
 		repo:               repo,
-		PomodoroDuration:   3 * time.Minute,
-		ShortBreakDuration: 1 * time.Minute,
-		LongBreakDuration:  2 * time.Minute,
+		PomodoroDuration:   25 * time.Minute,
+		ShortBreakDuration: 5 * time.Minute,
+		LongBreakDuration:  15 * time.Minute,
 	}
 
-	// if pomodoro > 0 {
-	// 	c.PomodoroDuration = pomodoro
-	// }
+	if pomodoro > 0 {
+		c.PomodoroDuration = pomodoro
+	}
 
-	// if shortBreak > 0 {
-	// 	c.ShortBreakDuration = shortBreak
-	// }
+	if shortBreak > 0 {
+		c.ShortBreakDuration = shortBreak
+	}
 
-	// if longBreak > 0 {
-	// 	c.LongBreakDuration = longBreak
-	// }
+	if longBreak > 0 {
+		c.LongBreakDuration = longBreak
+	}
 
 	return c
 }

--- a/pomodoro/interval.go
+++ b/pomodoro/interval.go
@@ -1,239 +1,265 @@
 package pomodoro
 
 import (
-  "context"
-  "errors"
-  "fmt"
-  "time"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/xasterKies/pomanalyzer/notif"
 )
 
 // Category constants
 const (
-  CategoryPomodoro   = "Pomodoro"
-  CategoryShortBreak = "ShortBreak"
-  CategoryLongBreak  = "LongBreak"
+	CategoryPomodoro   = "Pomodoro"
+	CategoryShortBreak = "ShortBreak"
+	CategoryLongBreak  = "LongBreak"
 )
 
 // State constants
 const (
-  StateNotStarted = iota
-  StateRunning
-  StatePaused
-  StateDone
-  StateCancelled
+	StateNotStarted = iota
+	StateRunning
+	StatePaused
+	StateDone
+	StateCancelled
 )
 
 type Interval struct {
-  ID              int64
-  StartTime       time.Time
-  PlannedDuration time.Duration
-  ActualDuration  time.Duration
-  Category        string
-  State           int
+	ID              int64
+	StartTime       time.Time
+	PlannedDuration time.Duration
+	ActualDuration  time.Duration
+	Category        string
+	State           int
 }
 
 var (
-  ErrNoIntervals = errors.New("No intervals")
-  ErrIntervalNotRunning = errors.New("Interval not running")
-  ErrIntervalCompleted = errors.New("Interval is completed or cancelled")
-  ErrInvalidState = errors.New("Invalid State")
-  ErrInvalidID = errors.New("Invalid ID")
+	ErrNoIntervals        = errors.New("No intervals")
+	ErrIntervalNotRunning = errors.New("Interval not running")
+	ErrIntervalCompleted  = errors.New("Interval is completed or cancelled")
+	ErrInvalidState       = errors.New("Invalid State")
+	ErrInvalidID          = errors.New("Invalid ID")
 )
 
 type Repository interface {
-  Create(i Interval) (int64, error)
-  Update(i Interval) error
-  ByID(id int64) (Interval, error)
-  Last() (Interval, error)
-  Breaks(n int) ([]Interval, error)
-  CategorySummary(day time.Time, filter string) (time.Duration, error)
+	Create(i Interval) (int64, error)
+	Update(i Interval) error
+	ByID(id int64) (Interval, error)
+	Last() (Interval, error)
+	Breaks(n int) ([]Interval, error)
+	CategorySummary(day time.Time, filter string) (time.Duration, error)
 }
 
 type IntervalConfig struct {
-  repo               Repository
-  PomodoroDuration   time.Duration
-  ShortBreakDuration time.Duration
-  LongBreakDuration  time.Duration
+	repo               Repository
+	PomodoroDuration   time.Duration
+	ShortBreakDuration time.Duration
+	LongBreakDuration  time.Duration
 }
 
 func NewConfig(repo Repository, pomodoro, shortBreak,
-  longBreak time.Duration) *IntervalConfig {
+	longBreak time.Duration) *IntervalConfig {
 
-  c := &IntervalConfig{
-    repo:               repo,
-    PomodoroDuration:   25 * time.Minute,
-    ShortBreakDuration: 5 * time.Minute,
-    LongBreakDuration:  15 * time.Minute,
-  }
+	c := &IntervalConfig{
+		repo:               repo,
+		PomodoroDuration:   3 * time.Minute,
+		ShortBreakDuration: 1 * time.Minute,
+		LongBreakDuration:  2 * time.Minute,
+	}
 
-  if pomodoro > 0 {
-    c.PomodoroDuration = pomodoro
-  }
+	// if pomodoro > 0 {
+	// 	c.PomodoroDuration = pomodoro
+	// }
 
-  if shortBreak > 0 {
-    c.ShortBreakDuration = shortBreak
-  }
+	// if shortBreak > 0 {
+	// 	c.ShortBreakDuration = shortBreak
+	// }
 
-  if longBreak > 0 {
-    c.LongBreakDuration = longBreak
-  }
+	// if longBreak > 0 {
+	// 	c.LongBreakDuration = longBreak
+	// }
 
-  return c
+	return c
 }
 
 func GetInterval(config *IntervalConfig) (Interval, error) {
-  i := Interval{}
-  var err error
+	i := Interval{}
+	var err error
 
-  i, err = config.repo.Last()
+	i, err = config.repo.Last()
 
-  if err != nil && err != ErrNoIntervals {
-    return i, err
-  }
+	if err != nil && err != ErrNoIntervals {
+		return i, err
+	}
 
-  if err == nil && i.State != StateCancelled && i.State != StateDone {
-    return i, nil
-  }
+	if err == nil && i.State != StateCancelled && i.State != StateDone {
+		return i, nil
+	}
 
-  return newInterval(config)
+	return newInterval(config)
 }
 
 func newInterval(config *IntervalConfig) (Interval, error) {
-  i := Interval{}
-  category, err := nextCategory(config.repo)
-  if err != nil {
-    return i, err
-  }
+	i := Interval{}
+	category, err := nextCategory(config.repo)
+	if err != nil {
+		return i, err
+	}
 
-  i.Category = category
+	i.Category = category
 
-  switch category {
-  case CategoryPomodoro:
-    i.PlannedDuration = config.PomodoroDuration
-  case CategoryShortBreak:
-    i.PlannedDuration = config.ShortBreakDuration
-  case CategoryLongBreak:
-    i.PlannedDuration = config.LongBreakDuration
-  }
+	switch category {
+	case CategoryPomodoro:
+		i.PlannedDuration = config.PomodoroDuration
+	case CategoryShortBreak:
+		i.PlannedDuration = config.ShortBreakDuration
+	case CategoryLongBreak:
+		i.PlannedDuration = config.LongBreakDuration
+	}
 
-  if i.ID, err = config.repo.Create(i); err != nil {
-    return i, err
-  }
+	if i.ID, err = config.repo.Create(i); err != nil {
+		return i, err
+	}
 
-  return i, nil
+	return i, nil
 }
 
 type Callback func(Interval)
 
 func (i Interval) Start(ctx context.Context, config *IntervalConfig,
-  start, periodic, end Callback) error {
+	start, periodic, end Callback) error {
 
-  switch i.State {
-  case StateRunning:
-    return nil
-  case StateNotStarted:
-    i.StartTime = time.Now()
-    fallthrough
-  case StatePaused:
-    i.State = StateRunning
-    if err := config.repo.Update(i); err != nil {
-      return err
-    }
-    return tick(ctx, i.ID, config, start, periodic, end)
-  case StateCancelled, StateDone:
-    return fmt.Errorf("%w: Cannot start", ErrIntervalCompleted)
-  default:
-    return fmt.Errorf("%w: %d", ErrInvalidState, i.State)
-  }
+	switch i.State {
+	case StateRunning:
+		return nil
+	case StateNotStarted:
+		i.StartTime = time.Now()
+		fallthrough
+	case StatePaused:
+		i.State = StateRunning
+		if err := config.repo.Update(i); err != nil {
+			return err
+		}
+		return tick(ctx, i.ID, config, start, periodic, end)
+	case StateCancelled, StateDone:
+		return fmt.Errorf("%w: Cannot start", ErrIntervalCompleted)
+	default:
+		return fmt.Errorf("%w: %d", ErrInvalidState, i.State)
+	}
 }
 
 func (i Interval) Pause(config *IntervalConfig) error {
-  if i.State != StateRunning {
-    return ErrIntervalNotRunning
-  }
+	if i.State != StateRunning {
+		return ErrIntervalNotRunning
+	}
 
-  i.State = StatePaused
+	i.State = StatePaused
 
-  return config.repo.Update(i)
+	return config.repo.Update(i)
 }
 
 func tick(ctx context.Context, id int64, config *IntervalConfig,
-  start, periodic, end Callback) error {
+	start, periodic, end Callback) error {
 
-  ticker := time.NewTicker(time.Second)
-  defer ticker.Stop()
+	ticker := time.NewTicker(time.Second)
 
-  i, err := config.repo.ByID(id)
-  if err != nil {
-    return err
-  }
-  expire := time.After(i.PlannedDuration - i.ActualDuration)
+	defer func() error {
+		i, err := config.repo.ByID(id)
 
-  start(i)
+		if err != nil {
+			return err
+		}
 
-  for {
-    select {
-    case <-ticker.C:
-      i, err := config.repo.ByID(id)
-      if err != nil {
-        return err
-      }
+		var message string
 
-      if i.State == StatePaused {
-        return nil
-      }
+		if i.State != StatePaused {
+			if i.Category == CategoryPomodoro {
+				message = "Time to take a break. Start break timer."
+			} else {
+				message = "Break is over. Restart pomodoro timer"
+			}
 
-      i.ActualDuration += time.Second
-      if err := config.repo.Update(i); err != nil {
-        return err
-      }
-      periodic(i)
-    case <-expire:
-      i, err := config.repo.ByID(id)
-      if err != nil {
-        return err
-      }
-      i.State = StateDone
-      end(i)
-      return config.repo.Update(i)
-    case <-ctx.Done():
-      i, err := config.repo.ByID(id)
-      if err != nil {
-        return err
-      }
-      i.State = StateCancelled
-      return config.repo.Update(i)
-    }
-  }
+			notification := notif.New("Pomanalyzer", message, notif.SeverityNormal)
+			notification.Send()
+		}
+
+		ticker.Stop()
+		return nil
+	}()
+
+	i, err := config.repo.ByID(id)
+	if err != nil {
+		return err
+	}
+
+	expire := time.After(i.PlannedDuration - i.ActualDuration)
+
+	start(i)
+
+	for {
+		select {
+		case <-ticker.C:
+			i, err := config.repo.ByID(id)
+			if err != nil {
+				return err
+			}
+
+			if i.State == StatePaused {
+				return nil
+			}
+
+			i.ActualDuration += time.Second
+			if err := config.repo.Update(i); err != nil {
+				return err
+			}
+			periodic(i)
+		case <-expire:
+			i, err := config.repo.ByID(id)
+			if err != nil {
+				return err
+			}
+			i.State = StateDone
+			end(i)
+			return config.repo.Update(i)
+		case <-ctx.Done():
+			i, err := config.repo.ByID(id)
+			if err != nil {
+				return err
+			}
+			i.State = StateCancelled
+			return config.repo.Update(i)
+		}
+	}
 }
 
 func nextCategory(r Repository) (string, error) {
-  li, err := r.Last()
-  if err != nil && err == ErrNoIntervals {
-    return CategoryPomodoro, nil
-  }
-  if err != nil {
-    return "", err
-  }
+	li, err := r.Last()
+	if err != nil && err == ErrNoIntervals {
+		return CategoryPomodoro, nil
+	}
+	if err != nil {
+		return "", err
+	}
 
-  if li.Category == CategoryLongBreak || li.Category == CategoryShortBreak {
-    return CategoryPomodoro, nil
-  }
+	if li.Category == CategoryLongBreak || li.Category == CategoryShortBreak {
+		return CategoryPomodoro, nil
+	}
 
-  lastBreaks, err := r.Breaks(3)
-  if err != nil {
-    return "", err
-  }
+	lastBreaks, err := r.Breaks(3)
+	if err != nil {
+		return "", err
+	}
 
-  if len(lastBreaks) < 3 {
-    return CategoryShortBreak, nil
-  }
+	if len(lastBreaks) < 3 {
+		return CategoryShortBreak, nil
+	}
 
-  for _, i := range lastBreaks {
-    if i.Category == CategoryLongBreak {
-      return CategoryShortBreak, nil
-    }
-  }
+	for _, i := range lastBreaks {
+		if i.Category == CategoryLongBreak {
+			return CategoryShortBreak, nil
+		}
+	}
 
-  return CategoryLongBreak, nil
+	return CategoryLongBreak, nil
 }


### PR DESCRIPTION
Fixes #5 

This PR introduces a notif package for notifications with sound alerts across Linux, macOS, and Windows.

**Key Changes:**

- New notif package for handling notifications.
- Cross-platform support:
      - Linux: Uses notify-send and plays sound via paplay or ogg123.
      - macOS: Uses terminal-notifier and afplay for system sounds.
      - Windows: Uses PowerShell for notifications and notify.wav for sound.
    
The sound file used is one that is present by default on the system.